### PR TITLE
check if window and navigator exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,14 +2,14 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 
 
 // Edge has a bug where scrollHeight is 1px bigger than clientHeight when there's no scroll.
-const isEdge = /Edge\/\d./i.test(navigator.userAgent);
+const isEdge = typeof navigator !== 'undefined' && /Edge\/\d./i.test(window.navigator.userAgent);
 
 
 // Small hook to use ResizeOberver if available. This fixes some issues when the component is resized.
 // This needs a polyfill to work on all browsers. The polyfill is not included in order to keep the package light.
 function useResizeObserver(ref, callback) {
   useEffect(() => {
-    if (window.ResizeObserver) {
+    if (typeof window !== 'undefined' && window.ResizeObserver) {
       const resizeObserver = new ResizeObserver((entries) => {
         callback(entries[0].contentRect);
       });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-element-scroll-hook",
-  "version": "1.0.8",
+  "version": "1.1.0",
   "description": "A react hook to use the scroll information of an element",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
In cases where this package is imported in a Server Sided Rendering context, there is no window object and also no navigator. I'd like to propose checks for window because builds would fail on `"navigator" is not available during server side rendering.`

With these checks the code is only executed when actually inside a browser.