### PR TITLE
ResizeObserver loop limit exceeded fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 
-
 // Edge has a bug where scrollHeight is 1px bigger than clientHeight when there's no scroll.
 const isEdge = typeof navigator !== 'undefined' && /Edge\/\d./i.test(window.navigator.userAgent);
-
 
 // Small hook to use ResizeOberver if available. This fixes some issues when the component is resized.
 // This needs a polyfill to work on all browsers. The polyfill is not included in order to keep the package light.
@@ -11,7 +9,13 @@ function useResizeObserver(ref, callback) {
   useEffect(() => {
     if (typeof window !== 'undefined' && window.ResizeObserver) {
       const resizeObserver = new ResizeObserver((entries) => {
-        callback(entries[0].contentRect);
+        // Wrap it in requestAnimationFrame to avoid this error - ResizeObserver loop limit exceeded
+        window.requestAnimationFrame(() => {
+          if (!Array.isArray(entries) || !entries.length) {
+            return;
+          }
+          callback(entries[0].contentRect);
+        });
       });
 
       resizeObserver.observe(ref.current);
@@ -22,7 +26,6 @@ function useResizeObserver(ref, callback) {
     }
   }, [ref]);
 };
-
 
 function throttle(func, wait) {
   let context, args, result;
@@ -141,9 +144,7 @@ function useScrollInfo() {
     }
   }, []);
 
-
   return [scroll, setRef, ref];
 }
-
 
 export default useScrollInfo;


### PR DESCRIPTION
Wrap callback of resizeObserver in requestAnimationframe to bundle the calls to avoid error ResizeObserver loop limit exceeded.