### PR TITLE
[FIX] replace direct window reference with navigator check for ssr compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ build/Release
 # Dependency directories
 node_modules/
 jspm_packages/
+package-lock.json
 
 # TypeScript v1 declaration files
 typings/

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 
 // Edge has a bug where scrollHeight is 1px bigger than clientHeight when there's no scroll.
-const isEdge = typeof navigator !== 'undefined' && /Edge\/\d./i.test(window.navigator.userAgent);
+const isEdge = typeof navigator !== 'undefined' && /Edge\/\d./i.test(navigator.userAgent);
 
 // Small hook to use ResizeOberver if available. This fixes some issues when the component is resized.
 // This needs a polyfill to work on all browsers. The polyfill is not included in order to keep the package light.


### PR DESCRIPTION
## Remove window reference from navigator.userAgent for SSR compatibility

### Problem
The Edge browser detection was using `window.navigator.userAgent` which causes issues when the code is parsed in Node.js environments (like during Server-Side Rendering). Even though there's a `typeof navigator !== 'undefined'` check, the direct `window.navigator` reference still breaks SSR compatibility.

### Solution
Simplified the Edge browser detection to use `navigator.userAgent` directly instead of `window.navigator.userAgent`. This change:

- **Prevents Node.js parsing errors**: Removes unnecessary `window` reference since `navigator` is already being checked
- **Maintains SSR compatibility**: The `typeof navigator !== 'undefined'` check already ensures safe access
- **Future-proof for Node.js v21+**: The `Navigator` global object was implemented in Node.js from v21, so using `navigator` directly (with proper checks) is more compatible
- **Preserves functionality**: The Edge-specific scrollHeight bug workaround continues to work exactly as before
- **Cleaner code**: Removes redundant `window.` prefix when `navigator` global is already being checked

This is a small but important fix for teams using this hook in SSR applications like Next.js, Nuxt.js, or other server-rendered React applications, and ensures better compatibility with modern Node.js versions.
